### PR TITLE
Remove request promise native

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,7 @@ async function doAnalysis(url: string) {
 
   page.on('request', request => {
     requests.push(request);
+    request.continue();
   });
 
   await page.goto(url, {
@@ -59,10 +60,10 @@ async function doAnalysis(url: string) {
   // create list of blocking URLs
   const toBlock = new Set<string>();
   for (const r of requests) {
-      const url = r.url();
-      if (getEntity(url)) {
-        toBlock.add(url);
-      }
+    const url = r.url();
+    if (getEntity(url)) {
+      toBlock.add(url);
+    }
   }
 
   // Lighthouse will open the URL.
@@ -101,6 +102,7 @@ async function runLHForURL(
     port: new URL(browser.wsEndpoint()).port,
     output: 'json',
     logLevel: 'info',
+    onlyCategories: ['performance', 'best-practices'],
     blockedUrlPatterns: [`*${toBlock}*`],
   });
 


### PR DESCRIPTION
Fixes #27 

Updated the code so that HTTPRequest from puppeteer is used. Also removed some of the complexity in getting the URLs in string format.

Also limited the Lighthouse categories to performance and best-practices to reduce the work being done by LH and speed up the results.

