### PR TITLE
Async poll for results and display as they become available - Docs fo…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,7 @@ under the License.
         text-align: center;
       }
     </style>
+    <script>var exports = {};</script>
     <script src="./ui.js"></script>
   </head>
   <body>

--- a/src/app.ts
+++ b/src/app.ts
@@ -29,7 +29,11 @@ app.get('/', (_, res) => {
 
 app.get('/status/:id', async (req, res) => {
   const execution = executions.find(e => e.id === req.params.id);
-  res.send(execution);
+  if (execution) {
+    res.send(execution);
+  } else {
+    res.sendStatus(404);
+  }
 });
 
 app.get('/test/:url', async (req, res) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@
  * Simplified Lighthouse response with only the fields required.
  */
 export type LHResponse = {
+  id: string;
   blockedURL: string;
   reportUrl: string;
   scores: {
@@ -35,4 +36,17 @@ export type LHReport = {
     audits: object;
   };
   report: string;
+};
+
+/**
+ * Represents an analysis request against an URL.
+ */
+export type AuditExecution = {
+  id: string;
+  status: string;
+  url: string;
+  userAgentOverride: string;
+  maxUrlsToTry?: number;
+  results: LHResponse[];
+  error?: string;
 };

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -66,13 +66,17 @@ async function pollForResults(executionId: string) {
       });
 
       if (response.status !== 'running') {
-        clearInterval(pollForResultsInterval);
+        if (pollForResultsInterval) {
+          clearInterval(pollForResultsInterval);
+        }
         (document.getElementById('submit') as HTMLButtonElement).disabled =
           false;
       }
     } catch (ex) {
       showError(ex.message);
-      clearInterval(pollForResultsInterval);
+      if (pollForResultsInterval) {
+        clearInterval(pollForResultsInterval);
+      }
       (document.getElementById('submit') as HTMLButtonElement).disabled = false;
     }
   }, 3000);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -46,7 +46,7 @@ function showError(message: string) {
   error.style.display = 'block';
 }
 
-var pollForResultsInterval = null;
+let pollForResultsInterval = null;
 /**
  * Poll regularly for results from backend for a specific id.
  * The backend will continue processing async.

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -12,15 +12,15 @@
 // License for the specific language governing permissions and limitations
 // under the License.
 
-import {LHResponse} from './types';
+import {AuditExecution, LHResponse} from './types';
 
-export function printResult(
-  table: HTMLTableElement,
-  baseline: LHResponse,
-  result: LHResponse,
-  index: number
-) {
-  const row = table.insertRow(1 + index);
+/**
+ * Inject information into the UI.
+ * @param result
+ */
+export function printResult(result: LHResponse) {
+  const table = document.getElementById('results') as HTMLTableElement;
+  const row = table.insertRow(table.rows.length);
   row.classList.add('result');
   const url = row.insertCell(0);
   if (result.blockedURL.length > 70) {
@@ -40,23 +40,78 @@ export function printResult(
   ).innerHTML = `<a href='${result.reportUrl}' target='_blank'>LINK</a>`;
 }
 
-function printResults(results: LHResponse[]) {
-  const table = document.getElementById('results') as HTMLTableElement;
-
-  document.querySelectorAll('.result').forEach(e => e.remove());
-  table.style.display = 'block';
-
-  results.forEach((result, index) =>
-    printResult(table, results[0], result, index)
-  );
-}
-
 function showError(message: string) {
   const error = document.getElementById('error');
   error.innerText = message;
   error.style.display = 'block';
 }
 
+var pollForResultsInterval = null;
+/**
+ * Poll regularly for results from backend for a specific id.
+ * The backend will continue processing async.
+ * @param executionId
+ */
+async function pollForResults(executionId: string) {
+  const processedResults: string[] = [];
+  pollForResultsInterval = setInterval(async () => {
+    try {
+      const response = await checkForResults(executionId);
+      const newResults = response.results.filter(
+        r => processedResults.indexOf(r.id) === -1
+      );
+      newResults.forEach(result => {
+        printResult(result);
+        processedResults.push(result.id);
+      });
+
+      if (response.status !== 'running') {
+        clearInterval(pollForResultsInterval);
+        (document.getElementById('submit') as HTMLButtonElement).disabled =
+          false;
+      }
+    } catch (ex) {
+      showError(ex.message);
+      clearInterval(pollForResultsInterval);
+      (document.getElementById('submit') as HTMLButtonElement).disabled = false;
+    }
+  }, 3000);
+}
+
+/**
+ * Execute HTTP request to check for new results from backend.
+ * @param executionId
+ * @returns
+ */
+async function checkForResults(executionId: string): Promise<AuditExecution> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function () {
+      if (this.readyState === 4) {
+        if (this.status === 200) {
+          const result: AuditExecution = JSON.parse(this.responseText);
+          if (result.error) {
+            showError(result.error);
+            reject(result.error);
+          } else {
+            resolve(result);
+          }
+        } else {
+          reject(new Error('Unexpected server error'));
+        }
+      }
+    };
+    xhr.open('GET', `/status/${executionId}?`, true);
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    xhr.send();
+  });
+}
+
+/**
+ * Handle UI form submission, requesting analysis for a URL.
+ * @param e
+ * @returns
+ */
 export function submit(e: Event) {
   e.preventDefault();
   const submitButton = document.getElementById('submit') as HTMLButtonElement;
@@ -64,25 +119,30 @@ export function submit(e: Event) {
   const userAgent = (document.getElementById('agent') as HTMLFormElement).value;
   const maxUrlsToTry = (document.getElementById('max') as HTMLFormElement)
     .value;
-  try {
-    submitButton.disabled = true;
-    const error = document.getElementById('error');
-    error.innerText = '';
-    error.style.display = 'none';
 
-    const table = document.getElementById('results');
-    table.style.display = 'none';
+  const table = document.getElementById('results') as HTMLTableElement;
+
+  document.querySelectorAll('.result').forEach(e => e.remove());
+  table.style.display = 'block';
+
+  submitButton.disabled = true;
+  const error = document.getElementById('error');
+  error.innerText = '';
+  error.style.display = 'none';
+
+  try {
     const xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function () {
       if (this.readyState === 4) {
-        submitButton.disabled = false;
-        const result = JSON.parse(this.responseText);
+        const result: {executionId: string; error?: string} = JSON.parse(
+          this.responseText
+        );
 
         if (this.status === 200) {
           if (result.error) {
             showError(result.error);
           } else {
-            printResults(result);
+            pollForResults(result.executionId);
           }
         } else {
           showError('Unexpected server error');

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -134,11 +134,10 @@ export function submit(e: Event) {
     const xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function () {
       if (this.readyState === 4) {
-        const result: {executionId: string; error?: string} = JSON.parse(
-          this.responseText
-        );
-
         if (this.status === 200) {
+          const result: {executionId: string; error?: string} = JSON.parse(
+            this.responseText
+          );
           if (result.error) {
             showError(result.error);
           } else {
@@ -146,6 +145,7 @@ export function submit(e: Event) {
           }
         } else {
           showError('Unexpected server error');
+          submitButton.disabled = false;
         }
       }
     };


### PR DESCRIPTION
Fixes #43

When submitting an UI request, an ID is returned, which the UI can use to poll for results. Now the UI displays results as they are available rather than when everything is complete, making for a smoother and rewarding user experience.

What do we think about this implementation?

- [x] Tests pass
- [x] Appropriate changes to README are included in PR