### PR TITLE
Include screenshots of page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,7 @@ under the License.
               <th>LCP</th>
               <th>FCP</th>
               <th>CLS</th>
+              <th>Screenshot</th>
               <th>Console Errors</th>
               <th>LH Report</th>
             </thead>

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type LHResponse = {
     consoleErrors: number;
   };
   error?: string;
+  screenshot?: string;
 };
 
 /**

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -57,9 +57,12 @@ export function printResult(result: LHResponse, baseline: LHResponse) {
   row.insertCell(1).innerText = `${result.scores.LCP} s${LCPImproved}`;
   row.insertCell(2).innerText = `${result.scores.FCP} s${FCPImproved}`;
   row.insertCell(3).innerText = `${result.scores.CLS}${CLSImproved}`;
-  row.insertCell(4).innerText = `${result.scores.consoleErrors}`;
   row.insertCell(
-    5
+    4
+  ).innerHTML = `<img src="data:image/png;base64, ${result.screenshot}" alt="Screenshot with ${result.blockedURL} blocked" width="70px" height="128px">`;
+  row.insertCell(5).innerText = `${result.scores.consoleErrors}`;
+  row.insertCell(
+    6
   ).innerHTML = `<a href='${result.reportUrl}' target='_blank'>LINK</a>`;
 }
 


### PR DESCRIPTION
Fixes #58 

Added a column to the results that shows a screenshot of the page with the blocked URL. 

Added generateScreenshot separate from generating the LH result to make it reusable if we move to using performance observer. Added the screenshot to the LH result type though, since it's more of a generalised result as opposed to the actual Lighthouse result. 